### PR TITLE
feat: Add credential provider

### DIFF
--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/auth/Base64Utils.android.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/auth/Base64Utils.android.kt
@@ -1,0 +1,13 @@
+package software.momento.kotlin.sdk.auth
+
+import java.nio.charset.StandardCharsets
+import android.util.Base64
+
+public actual fun decodeBase64(encoded: String): String? {
+    return try {
+        val decoded = Base64.decode(encoded, Base64.DEFAULT)
+        String(decoded, StandardCharsets.UTF_8)
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/src/androidUnitTest/kotlin/software/momento/kotlin/sdk/UsingTestRunner.android.kt
+++ b/src/androidUnitTest/kotlin/software/momento/kotlin/sdk/UsingTestRunner.android.kt
@@ -1,0 +1,12 @@
+package software.momento.kotlin.sdk
+
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest= Config.NONE)
+actual abstract class UsingTestRunner {
+
+}

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/auth/Base64Utils.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/auth/Base64Utils.kt
@@ -1,0 +1,15 @@
+package software.momento.kotlin.sdk.auth
+
+/**
+ * Expect function for decoding base64 encoded string. Required because android and JVM use different Base64 classes
+ * before Android API 26.
+ * @param encoded A base64 encoded string.
+ * @return A decoded string or null if the string is not valid base64.
+ */
+public expect fun decodeBase64(encoded: String): String?
+
+/**
+ * String extension function for decoding base64 encoded string.
+ * @return The decoded string or null if the string is not valid base64.
+ */
+public fun String.decodeBase64(): String? = decodeBase64(this)

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/auth/CredentialProvider.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/auth/CredentialProvider.kt
@@ -1,0 +1,85 @@
+package software.momento.kotlin.sdk.auth
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
+
+/**
+ * Contains the information required for a Momento client to connect to and authenticate with
+ * the Momento service.
+ */
+public data class CredentialProvider(
+    val controlEndpoint: String, val cacheEndpoint: String, val apiKey: String
+) {
+    public companion object {
+        //TODO: throw Momento exceptions when those are added
+
+        /**
+         * Creates a [CredentialProvider] from a Momento API key.
+         * @param apiKey The Momento API key to use for authentication.
+         * @param controlHost An optional override for the endpoint used for control operations.
+         * @param cacheHost An optional override for the endpoint used for cache operations.
+         */
+        public fun fromString(
+            apiKey: String, controlHost: String? = null, cacheHost: String? = null
+        ): CredentialProvider {
+            try {
+                val provider = try {
+                    processLegacyKey(apiKey)
+                } catch (e: Exception) {
+                    processV1Key(apiKey)
+                }
+                return provider.copy(
+                    controlEndpoint = controlHost ?: provider.controlEndpoint,
+                    cacheEndpoint = cacheHost ?: provider.cacheEndpoint
+                )
+            } catch (e: Exception) {
+                throw IllegalArgumentException("Invalid API key")
+            }
+        }
+
+        /**
+         * Creates a [CredentialProvider] from a Momento API key stored in an environment variable.
+         * @param envVar The name of the environment variable containing the Momento API key.
+         * @param controlHost An optional override for the endpoint used for control operations.
+         * @param cacheHost An optional override for the endpoint used for cache operations.
+         */
+        public fun fromEnvVar(
+            envVar: String, controlHost: String? = null, cacheHost: String? = null
+        ): CredentialProvider {
+            val apiKey = System.getenv(envVar) ?: throw IllegalArgumentException("Environment variable $envVar not set")
+            return fromString(apiKey, controlHost, cacheHost)
+        }
+
+        private val json: Json = Json { ignoreUnknownKeys = true }
+        private fun processLegacyKey(apiKey: String): CredentialProvider {
+            val keyParts = apiKey.split(".")
+            if (keyParts.size != 3) {
+                throw IllegalArgumentException("Malformed legacy API key")
+            }
+
+            val payloadJson = keyParts[1].decodeBase64() ?: throw IllegalArgumentException("Cannot decode base64")
+            val payload = json.decodeFromString<LegacyKeyPayload>(payloadJson)
+
+            return CredentialProvider(payload.controlEndpoint, payload.cacheEndpoint, apiKey)
+        }
+
+        private fun processV1Key(apiKey: String): CredentialProvider {
+            val decodedString = apiKey.decodeBase64() ?: throw IllegalArgumentException("Cannot decode base64")
+            val v1Key = json.decodeFromString<V1Key>(decodedString)
+
+            return CredentialProvider("control.${v1Key.host}", "cache.${v1Key.host}", v1Key.apiKey)
+        }
+
+        @Serializable
+        private data class V1Key(
+            @SerialName("endpoint") val host: String, @SerialName("api_key") val apiKey: String
+        )
+
+        @Serializable
+        private data class LegacyKeyPayload(
+            @SerialName("cp") val controlEndpoint: String, @SerialName("c") val cacheEndpoint: String
+        )
+    }
+}

--- a/src/commonTest/kotlin/software/momento/kotlin/sdk/UsingTestRunner.kt
+++ b/src/commonTest/kotlin/software/momento/kotlin/sdk/UsingTestRunner.kt
@@ -1,0 +1,4 @@
+package software.momento.kotlin.sdk
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+expect abstract class UsingTestRunner()

--- a/src/commonTest/kotlin/software/momento/kotlin/sdk/auth/CredentialProviderTest.kt
+++ b/src/commonTest/kotlin/software/momento/kotlin/sdk/auth/CredentialProviderTest.kt
@@ -1,0 +1,141 @@
+package software.momento.kotlin.sdk.auth
+
+import software.momento.kotlin.sdk.UsingTestRunner
+import java.util.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CredentialProviderTest : UsingTestRunner() {
+
+    companion object {
+        private const val CONTROL_ENDPOINT_LEGACY = "control.example.com"
+        private const val CACHE_ENDPOINT_LEGACY = "cache.example.com"
+        private const val CONTROL_ENDPOINT_V1 = "control.test.momentohq.com"
+        private const val CACHE_ENDPOINT_V1 = "cache.test.momentohq.com"
+
+        // Test tokens are all fake and nonfunctional.
+
+        private const val LEGACY_API_KEY_VALID =
+            ("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImNwIjoiY29udHJvbC5leGFtcGxlLmNvbSIsImMiOiJjYWNoZS5leGFtcG" +
+                    "xlLmNvbSJ9.YY7RSMBCpMRs_qgbNkW0PYC2eX-MukLixLWJyvBpnMVaOba-OV0G5jgNmNbtn4zaLT8tlEncV6wQ_CkTI_PvoA")
+        private const val V1_API_KEY_VALID =
+            ("eyJhcGlfa2V5IjogImV5SjBlWEFpT2lKS1YxUWlMQ0poYkdjaU9pSklVekkxTmlKOS5leUpwYzNNaU9pSlBibXhwYm1VZ1NsZFVJRUo" +
+                    "xYVd4a1pYSWlMQ0pwWVhRaU9qRTJOemd6TURVNE1USXNJbVY0Y0NJNk5EZzJOVFV4TlRReE1pd2lZWFZrSWpvaUlpd2ljM1Z" +
+                    "pSWpvaWFuSnZZMnRsZEVCbGVHRnRjR3hsTG1OdmJTSjkuOEl5OHE4NExzci1EM1lDb19IUDRkLXhqSGRUOFVDSXV2QVljeGh" +
+                    "GTXl6OCIsICJlbmRwb2ludCI6ICJ0ZXN0Lm1vbWVudG9ocS5jb20ifQ==")
+        private const val V1_INNER_KEY =
+            ("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2NzgzMDU4MTIsImV4cC" +
+                    "I6NDg2NTUxNTQxMiwiYXVkIjoiIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSJ9.8Iy8q84Lsr-D3YCo_HP4d-xjHdT8U" +
+                    "CIuvAYcxhFMyz8")
+        private const val V1_API_KEY_MISSING_ENDPOINT =
+            ("eyJhcGlfa2V5IjogImV5SmxibVJ3YjJsdWRDSTZJbU5sYkd3dE5DMTFjeTEzWlhOMExUSXRNUzV3Y205a0xtRXViVzl0Wlc1MGIyaHh" +
+                    "MbU52YlNJc0ltRndhVjlyWlhraU9pSmxlVXBvWWtkamFVOXBTa2xWZWtreFRtbEtPUzVsZVVwNlpGZEphVTlwU25kYVdGSnN" +
+                    "URzFrYUdSWVVuQmFXRXBCV2pJeGFHRlhkM1ZaTWpsMFNXbDNhV1J0Vm5sSmFtOTRabEV1VW5OMk9GazVkRE5KVEMwd1RHRjZ" +
+                    "iQzE0ZDNaSVZESmZZalJRZEhGTlVVMDVRV3hhVlVsVGFrbENieUo5In0=")
+        private const val V1_API_KEY_MISSING_KEY = "eyJlbmRwb2ludCI6ICJhLmIuY29tIn0="
+        const val LEGACY_API_KEY_MISSING_CONTROL_TOKEN =
+            ("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImMiOiJjYWNoZS5leGFtcGxlLmNvbSJ9.RzLpBXut4s0fEXHtVIYVNb6Z8" +
+                    "tiHSP9iu2j6OJpJHDksNXuOgTVFlMyG4V3gvMLMUwQmgtov-U9pMbaghQnr-Q")
+        const val LEGACY_API_KEY_MISSING_CACHE_TOKEN =
+            ("eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzcXVpcnJlbCIsImNwIjoiY29udHJvbC5leGFtcGxlLmNvbSJ9.obg5-runV-bdp0ZTV_2DG" +
+                    "DFdRfc6aIRHaSBGbK3QaACPXwF6e8ghBYg2LDXXOWgbdpy6wEfDVIPgYZ0yXxVqvg")
+    }
+
+    @Test
+    fun testCredentialProviderMissingEnvVar() {
+        val envVar = UUID.randomUUID().toString()
+        try {
+            CredentialProvider.fromEnvVar(envVar)
+        } catch (e: IllegalArgumentException) {
+            assertEquals("Environment variable $envVar not set", e.message)
+        }
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testCredentialProviderUnparsableToken() {
+        CredentialProvider.fromString("this isn't a real Token")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testCredentialProviderNoControlEndpoint() {
+        CredentialProvider.fromString(LEGACY_API_KEY_MISSING_CONTROL_TOKEN)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testCredentialProviderNoCacheEndpoint() {
+        CredentialProvider.fromString(LEGACY_API_KEY_MISSING_CACHE_TOKEN)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testCredentialProviderV1NoApiKey() {
+        CredentialProvider.fromString(V1_API_KEY_MISSING_KEY)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testCredentialProviderV1NoEndpoint() {
+        CredentialProvider.fromString(V1_API_KEY_MISSING_ENDPOINT)
+    }
+
+    @Test
+    fun testCredentialProviderLegacyTokenHappyPath() {
+        val provider = CredentialProvider.fromString(LEGACY_API_KEY_VALID)
+        assertEquals(LEGACY_API_KEY_VALID, provider.apiKey)
+        assertEquals(CONTROL_ENDPOINT_LEGACY, provider.controlEndpoint)
+        assertEquals(CACHE_ENDPOINT_LEGACY, provider.cacheEndpoint)
+    }
+
+    @Test
+    fun testCredentialProviderLegacyTokenOverrideEndpointsHappyPath() {
+        val controlOverride = "my.control.host"
+        val cacheOverride = "my.cache.host"
+
+        val controlOverrideProvider =
+            CredentialProvider.fromString(LEGACY_API_KEY_VALID, controlHost = controlOverride)
+        assertEquals(LEGACY_API_KEY_VALID, controlOverrideProvider.apiKey)
+        assertEquals(controlOverride, controlOverrideProvider.controlEndpoint)
+        assertEquals(CACHE_ENDPOINT_LEGACY, controlOverrideProvider.cacheEndpoint)
+
+        val cacheOverrideProvider = CredentialProvider.fromString(LEGACY_API_KEY_VALID, cacheHost = cacheOverride)
+        assertEquals(LEGACY_API_KEY_VALID, cacheOverrideProvider.apiKey)
+        assertEquals(CONTROL_ENDPOINT_LEGACY, cacheOverrideProvider.controlEndpoint)
+        assertEquals(cacheOverride, cacheOverrideProvider.cacheEndpoint)
+
+        val bothOverrideProvider = CredentialProvider.fromString(
+            LEGACY_API_KEY_VALID, controlHost = controlOverride, cacheHost = cacheOverride
+        )
+        assertEquals(LEGACY_API_KEY_VALID, bothOverrideProvider.apiKey)
+        assertEquals(controlOverride, bothOverrideProvider.controlEndpoint)
+        assertEquals(cacheOverride, bothOverrideProvider.cacheEndpoint)
+    }
+
+    @Test
+    fun testCredentialProviderV1TokenHappyPath() {
+        val provider = CredentialProvider.fromString(V1_API_KEY_VALID)
+        assertEquals(V1_INNER_KEY, provider.apiKey)
+        assertEquals(CONTROL_ENDPOINT_V1, provider.controlEndpoint)
+        assertEquals(CACHE_ENDPOINT_V1, provider.cacheEndpoint)
+    }
+
+    @Test
+    fun testCredentialProviderV1TokenOverrideEndpointsHappyPath() {
+        val controlOverride = "my.control.host"
+        val cacheOverride = "my.cache.host"
+
+        val controlOverrideProvider = CredentialProvider.fromString(V1_API_KEY_VALID, controlHost = controlOverride)
+        assertEquals(V1_INNER_KEY, controlOverrideProvider.apiKey)
+        assertEquals(controlOverride, controlOverrideProvider.controlEndpoint)
+        assertEquals(CACHE_ENDPOINT_V1, controlOverrideProvider.cacheEndpoint)
+
+        val cacheOverrideProvider = CredentialProvider.fromString(V1_API_KEY_VALID, cacheHost = cacheOverride)
+        assertEquals(V1_INNER_KEY, cacheOverrideProvider.apiKey)
+        assertEquals(CONTROL_ENDPOINT_V1, cacheOverrideProvider.controlEndpoint)
+        assertEquals(cacheOverride, cacheOverrideProvider.cacheEndpoint)
+
+        val bothOverrideProvider =
+            CredentialProvider.fromString(V1_API_KEY_VALID, controlHost = controlOverride, cacheHost = cacheOverride)
+        assertEquals(V1_INNER_KEY, bothOverrideProvider.apiKey)
+        assertEquals(controlOverride, bothOverrideProvider.controlEndpoint)
+        assertEquals(cacheOverride, bothOverrideProvider.cacheEndpoint)
+    }
+}
+

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/auth/Base64Utils.jvm.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/auth/Base64Utils.jvm.kt
@@ -1,0 +1,14 @@
+package software.momento.kotlin.sdk.auth
+
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+
+public actual fun decodeBase64(encoded: String): String? {
+    return try {
+        @Suppress("NewApi") // The android implementation uses android.util.Base64
+        val decoded = Base64.getDecoder().decode(encoded)
+        String(decoded, StandardCharsets.UTF_8)
+    } catch (e: Exception) {
+        null
+    }
+}

--- a/src/jvmTest/kotlin/software/momento/kotlin/sdk/UsingTestRunner.jvm.kt
+++ b/src/jvmTest/kotlin/software/momento/kotlin/sdk/UsingTestRunner.jvm.kt
@@ -1,0 +1,6 @@
+package software.momento.kotlin.sdk
+
+@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
+actual abstract class UsingTestRunner {
+
+}


### PR DESCRIPTION
Add class for parsing Momento API keys from strings or the command line.

Add a base 64 decoding compatibility function since android and jvm use different Base64 classes before api level 26.

Add an expect/actual test runner so that the common tests can use android libraries in the android target.