### PR TITLE
feat: add initial jvm topic client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # Momento Kotlin SDK
 
-Requires the android sdk installed and the ANDROID_HOME environment variable set.
+Requires the android sdk installed and the ANDROID_HOME environment variable set:
+```bash
+export ANDROID_HOME=/Users/{user}/Library/Android/sdk
+export PATH=$PATH:$ANDROID_HOME/emulator
+export PATH=$PATH:$ANDROID_HOME/tools
+export PATH=$PATH:$ANDROID_HOME/tools/bin
+export PATH=$PATH:$ANDROID_HOME/platform-tools
+```
+## Testing
+### Intellij
+Android instrumented tests can be run by running them through IntelliJ with the Android plugin or Android Studio.
+The `TEST_API_KEY` must be set in your `.zshrc` or somewhere else IntelliJ can read it when it executes the gradle project. The tests cannot directly read environment variables from the host machine, so `TEST_API_KEY` is read by the gradle project and stored in a test property.
+
+### Command Line
+Android instrumented tests can be run from the command line by first starting an emulator:
+```bash
+emulator -list-avds # list available emulators
+emulator -avd {one of the listed emulators} # start the emulator
+```
+Then run the tests:
+```bash
+./gradlew connectedAndroidTest
+```
+`TEST_API_KEY` must be set for the tests to work.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,12 +35,14 @@ kotlin {
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test-junit"))
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
             }
         }
         val jvmMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-jdk8"))
                 implementation("software.momento.kotlin:client-protos-jvm:0.1.0-SNAPSHOT")
+                runtimeOnly("io.grpc:grpc-netty:1.57.2")
             }
         }
         val jvmTest by getting {
@@ -51,6 +53,7 @@ kotlin {
         val androidMain by getting {
             dependencies {
                 implementation("software.momento.kotlin:client-protos-android:0.1.0-SNAPSHOT")
+                runtimeOnly("io.grpc:grpc-okhttp:1.57.2")
             }
         }
         val androidUnitTest by getting {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,11 +11,19 @@ repositories {
 }
 
 android {
-    namespace = "software.momento.kotlin"
+    namespace = "software.momento.kotlin.sdk"
 
     compileSdk = 34
     defaultConfig {
-        minSdk = 21
+        minSdk = 23
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunnerArguments["TestApiKey"] = System.getenv("TEST_API_KEY") ?: "noApiKeySet"
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
     }
 }
 
@@ -60,6 +68,13 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-junit"))
                 implementation("org.robolectric:robolectric:4.11.1")
+            }
+        }
+        val androidInstrumentedTest by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+                implementation("androidx.test.ext:junit:1.1.5")
+                implementation("androidx.test.espresso:espresso-core:3.5.1")
             }
         }
     }

--- a/src/androidInstrumentedTest/AndroidManifest.xml
+++ b/src/androidInstrumentedTest/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          android:versionCode="1"
+          android:versionName="1.0" >
+
+
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>

--- a/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
+++ b/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
@@ -1,0 +1,32 @@
+package software.momento.kotlin.sdk
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import software.momento.kotlin.sdk.auth.CredentialProvider
+import software.momento.kotlin.sdk.config.TopicConfiguration
+import software.momento.kotlin.sdk.responses.topic.TopicPublishResponse
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class TopicClientTest {
+
+    @Test
+    fun testPublish() = runTest {
+        val arguments = InstrumentationRegistry.getArguments()
+        val apiKey = arguments.getString("TestApiKey")!!
+
+        val topicClient = TopicClient(
+            credentialProvider = CredentialProvider.fromString(apiKey),
+            configuration = TopicConfiguration.Companion.Laptop.Latest
+        )
+        val response = topicClient.publish("cache", "topic", "android!")
+        if (response is TopicPublishResponse.Error) {
+            println(response.cause)
+        }
+        assert(response is TopicPublishResponse.Success)
+    }
+}

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/TopicClient.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/TopicClient.kt
@@ -1,0 +1,23 @@
+package software.momento.kotlin.sdk
+
+import software.momento.kotlin.sdk.auth.CredentialProvider
+import software.momento.kotlin.sdk.config.TopicConfiguration
+import software.momento.kotlin.sdk.internal.InternalTopicClient
+import software.momento.kotlin.sdk.responses.topic.TopicPublishResponse
+import java.io.Closeable
+
+public class TopicClient(credentialProvider: CredentialProvider, configuration: TopicConfiguration): Closeable {
+    private val internalTopicClient: InternalTopicClient
+
+    init {
+        internalTopicClient = InternalTopicClient(credentialProvider, configuration)
+    }
+
+    public suspend fun publish(cacheName: String, topicName: String, value: String): TopicPublishResponse {
+        return internalTopicClient.publish(cacheName, topicName, value)
+    }
+
+    override fun close() {
+        internalTopicClient.close()
+    }
+}

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/InternalTopicClient.android.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/InternalTopicClient.android.kt
@@ -1,0 +1,55 @@
+package software.momento.kotlin.sdk.internal
+
+import grpc.cache_client.pubsub._PublishRequest
+import grpc.cache_client.pubsub._TopicValue
+import io.grpc.Metadata
+import software.momento.kotlin.sdk.auth.CredentialProvider
+import software.momento.kotlin.sdk.config.TopicConfiguration
+import software.momento.kotlin.sdk.exceptions.CacheServiceExceptionMapper
+import software.momento.kotlin.sdk.responses.topic.TopicPublishResponse
+import java.io.Closeable
+
+internal actual class InternalTopicClient actual constructor(
+    credentialProvider: CredentialProvider, configuration: TopicConfiguration
+): Closeable {
+
+    private val stubsManager: TopicGrpcStubsManager
+
+    init {
+        stubsManager = TopicGrpcStubsManager(credentialProvider)
+    }
+
+    internal actual suspend fun publish(
+        cacheName: String, topicName: String, value: String
+    ): TopicPublishResponse {
+        val metadata = metadataWithCache(cacheName)
+
+        val request = _PublishRequest.newBuilder()
+            .setCacheName(cacheName)
+            .setTopic(topicName)
+            .setValue(_TopicValue.newBuilder().setText(value).build())
+            .build()
+
+        try {
+            stubsManager.stub.publish(request, metadata)
+        } catch (e: Exception) {
+            return TopicPublishResponse.Error(CacheServiceExceptionMapper.convert(e, metadata))
+        }
+
+        return TopicPublishResponse.Success
+    }
+
+    companion object {
+        private val CACHE_NAME_KEY = Metadata.Key.of("cache", Metadata.ASCII_STRING_MARSHALLER)
+
+        fun metadataWithCache(cacheName: String): Metadata {
+            val metadata = Metadata()
+            metadata.put(CACHE_NAME_KEY, cacheName)
+            return metadata
+        }
+    }
+
+    override fun close() {
+        stubsManager.close()
+    }
+}

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
@@ -1,0 +1,62 @@
+package software.momento.kotlin.sdk.internal
+
+import grpc.cache_client.pubsub.PubsubGrpcKt
+import io.grpc.ClientInterceptor
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import software.momento.kotlin.sdk.auth.CredentialProvider
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.minutes
+
+
+/**
+ * Manager responsible for GRPC channels and stubs for the Control Plane.
+ *
+ *
+ * The business layer, will get request stubs from this layer. This keeps the two layers
+ * independent and any future pooling of channels can happen exclusively in the manager without
+ * impacting the API business logic.
+ */
+internal class TopicGrpcStubsManager(credentialProvider: CredentialProvider) : Closeable {
+    private val channel: ManagedChannel
+    private val futureStub: PubsubGrpcKt.PubsubCoroutineStub
+
+    init {
+        channel = setupConnection(credentialProvider)
+        futureStub = PubsubGrpcKt.PubsubCoroutineStub(channel)
+    }
+
+    val stub: PubsubGrpcKt.PubsubCoroutineStub
+        /**
+         * Returns a stub with appropriate deadlines.
+         *
+         *
+         * Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
+         * When a deadline is set on a stub, it simply means that once the stub is created it must be used
+         * before the deadline expires. Hence, the stub returned from here should never be cached and the
+         * safest behavior is for clients to request a new stub each time.
+         *
+         *
+         * [more information](https://github.com/grpc/grpc-java/issues/1495)
+         */
+        get() = futureStub.withDeadlineAfter(DEADLINE.inWholeSeconds, TimeUnit.SECONDS)
+
+    override fun close() {
+        channel.shutdown()
+    }
+
+    companion object {
+        private val DEADLINE = 1.minutes
+        private fun setupConnection(credentialProvider: CredentialProvider): ManagedChannel {
+            val channelBuilder = ManagedChannelBuilder.forAddress(credentialProvider.cacheEndpoint, 443)
+            channelBuilder.useTransportSecurity()
+            channelBuilder.disableRetry()
+            val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
+            channelBuilder.intercept(clientInterceptors)
+            return channelBuilder.build()
+        }
+    }
+}
+

--- a/src/androidUnitTest/kotlin/software/momento/kotlin/sdk/UsingTestRunner.android.kt
+++ b/src/androidUnitTest/kotlin/software/momento/kotlin/sdk/UsingTestRunner.android.kt
@@ -2,11 +2,9 @@ package software.momento.kotlin.sdk
 
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
 
 @Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 @RunWith(RobolectricTestRunner::class)
-@Config(manifest= Config.NONE)
 actual abstract class UsingTestRunner {
 
 }

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/auth/CredentialProvider.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/auth/CredentialProvider.kt
@@ -3,6 +3,7 @@ package software.momento.kotlin.sdk.auth
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
+import software.momento.kotlin.sdk.exceptions.InvalidArgumentException
 
 /**
  * Contains the information required for a Momento client to connect to and authenticate with
@@ -12,8 +13,6 @@ public data class CredentialProvider(
     val controlEndpoint: String, val cacheEndpoint: String, val apiKey: String
 ) {
     public companion object {
-        //TODO: throw Momento exceptions when those are added
-
         /**
          * Creates a [CredentialProvider] from a Momento API key.
          * @param apiKey The Momento API key to use for authentication.
@@ -34,7 +33,7 @@ public data class CredentialProvider(
                     cacheEndpoint = cacheHost ?: provider.cacheEndpoint
                 )
             } catch (e: Exception) {
-                throw IllegalArgumentException("Invalid API key")
+                throw InvalidArgumentException("Invalid API key")
             }
         }
 
@@ -47,7 +46,7 @@ public data class CredentialProvider(
         public fun fromEnvVar(
             envVar: String, controlHost: String? = null, cacheHost: String? = null
         ): CredentialProvider {
-            val apiKey = System.getenv(envVar) ?: throw IllegalArgumentException("Environment variable $envVar not set")
+            val apiKey = System.getenv(envVar) ?: throw InvalidArgumentException("Environment variable $envVar not set")
             return fromString(apiKey, controlHost, cacheHost)
         }
 
@@ -55,17 +54,17 @@ public data class CredentialProvider(
         private fun processLegacyKey(apiKey: String): CredentialProvider {
             val keyParts = apiKey.split(".")
             if (keyParts.size != 3) {
-                throw IllegalArgumentException("Malformed legacy API key")
+                throw InvalidArgumentException("Malformed legacy API key")
             }
 
-            val payloadJson = keyParts[1].decodeBase64() ?: throw IllegalArgumentException("Cannot decode base64")
+            val payloadJson = keyParts[1].decodeBase64() ?: throw InvalidArgumentException("Cannot decode base64")
             val payload = json.decodeFromString<LegacyKeyPayload>(payloadJson)
 
             return CredentialProvider(payload.controlEndpoint, payload.cacheEndpoint, apiKey)
         }
 
         private fun processV1Key(apiKey: String): CredentialProvider {
-            val decodedString = apiKey.decodeBase64() ?: throw IllegalArgumentException("Cannot decode base64")
+            val decodedString = apiKey.decodeBase64() ?: throw InvalidArgumentException("Cannot decode base64")
             val v1Key = json.decodeFromString<V1Key>(decodedString)
 
             return CredentialProvider("control.${v1Key.host}", "cache.${v1Key.host}", v1Key.apiKey)

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/internal/InternalTopicClient.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/internal/InternalTopicClient.kt
@@ -1,0 +1,12 @@
+package software.momento.kotlin.sdk.internal
+
+import software.momento.kotlin.sdk.auth.CredentialProvider
+import software.momento.kotlin.sdk.config.TopicConfiguration
+import software.momento.kotlin.sdk.responses.topic.TopicPublishResponse
+import java.io.Closeable
+
+internal expect class InternalTopicClient(credentialProvider: CredentialProvider, configuration: TopicConfiguration) :
+    Closeable {
+
+    internal suspend fun publish(cacheName: String, topicName: String, value: String): TopicPublishResponse
+}

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.kt
@@ -1,0 +1,36 @@
+package software.momento.kotlin.sdk.internal
+
+import kotlin.concurrent.Volatile
+
+internal class UserHeaderInterceptor(private val tokenValue: String) : io.grpc.ClientInterceptor {
+    private val sdkVersion = String.format("java:%s", this.javaClass.getPackage().implementationVersion)
+    override fun <ReqT, RespT> interceptCall(
+        methodDescriptor: io.grpc.MethodDescriptor<ReqT, RespT>,
+        callOptions: io.grpc.CallOptions,
+        channel: io.grpc.Channel
+    ): io.grpc.ClientCall<ReqT, RespT> {
+        return object : io.grpc.ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+            channel.newCall(methodDescriptor, callOptions)
+        ) {
+            override fun start(listener: Listener<RespT>, metadata: io.grpc.Metadata) {
+                metadata.put(AUTH_HEADER_KEY, tokenValue)
+                if (!isUserAgentSent) {
+                    metadata.put(SDK_AGENT_KEY, sdkVersion)
+                    isUserAgentSent = true
+                }
+                super.start(listener, metadata)
+            }
+        }
+    }
+
+    companion object {
+        private val AUTH_HEADER_KEY: io.grpc.Metadata.Key<String> =
+            io.grpc.Metadata.Key.of("Authorization", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
+        private val SDK_AGENT_KEY: io.grpc.Metadata.Key<String> =
+            io.grpc.Metadata.Key.of("Agent", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
+
+        @Volatile
+        private var isUserAgentSent = false
+    }
+}
+

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/responses/topic/TopicPublishResponse.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/responses/topic/TopicPublishResponse.kt
@@ -1,0 +1,10 @@
+package software.momento.kotlin.sdk.responses.topic
+
+import software.momento.kotlin.sdk.exceptions.SdkException
+
+public sealed interface TopicPublishResponse {
+
+    public object Success : TopicPublishResponse
+
+    public class Error(cause: SdkException): SdkException(cause), TopicPublishResponse
+}

--- a/src/commonTest/kotlin/software/momento/kotlin/sdk/auth/CredentialProviderTest.kt
+++ b/src/commonTest/kotlin/software/momento/kotlin/sdk/auth/CredentialProviderTest.kt
@@ -1,8 +1,10 @@
 package software.momento.kotlin.sdk.auth
 
 import software.momento.kotlin.sdk.UsingTestRunner
+import software.momento.kotlin.sdk.exceptions.InvalidArgumentException
 import java.util.*
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class CredentialProviderTest : UsingTestRunner() {
@@ -46,32 +48,32 @@ class CredentialProviderTest : UsingTestRunner() {
         val envVar = UUID.randomUUID().toString()
         try {
             CredentialProvider.fromEnvVar(envVar)
-        } catch (e: IllegalArgumentException) {
-            assertEquals("Environment variable $envVar not set", e.message)
+        } catch (e: InvalidArgumentException) {
+            assertContains(e.message!!, "not set")
         }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test(expected = InvalidArgumentException::class)
     fun testCredentialProviderUnparsableToken() {
         CredentialProvider.fromString("this isn't a real Token")
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test(expected = InvalidArgumentException::class)
     fun testCredentialProviderNoControlEndpoint() {
         CredentialProvider.fromString(LEGACY_API_KEY_MISSING_CONTROL_TOKEN)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test(expected = InvalidArgumentException::class)
     fun testCredentialProviderNoCacheEndpoint() {
         CredentialProvider.fromString(LEGACY_API_KEY_MISSING_CACHE_TOKEN)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test(expected = InvalidArgumentException::class)
     fun testCredentialProviderV1NoApiKey() {
         CredentialProvider.fromString(V1_API_KEY_MISSING_KEY)
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test(expected = InvalidArgumentException::class)
     fun testCredentialProviderV1NoEndpoint() {
         CredentialProvider.fromString(V1_API_KEY_MISSING_ENDPOINT)
     }

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/TopicClient.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/TopicClient.kt
@@ -1,0 +1,23 @@
+package software.momento.kotlin.sdk
+
+import software.momento.kotlin.sdk.auth.CredentialProvider
+import software.momento.kotlin.sdk.config.TopicConfiguration
+import software.momento.kotlin.sdk.internal.InternalTopicClient
+import software.momento.kotlin.sdk.responses.topic.TopicPublishResponse
+import java.io.Closeable
+
+public class TopicClient(credentialProvider: CredentialProvider, configuration: TopicConfiguration): Closeable {
+    private val internalTopicClient: InternalTopicClient
+
+    init {
+        internalTopicClient = InternalTopicClient(credentialProvider, configuration)
+    }
+
+    public suspend fun publish(cacheName: String, topicName: String, value: String): TopicPublishResponse {
+        return internalTopicClient.publish(cacheName, topicName, value)
+    }
+
+    override fun close() {
+        internalTopicClient.close()
+    }
+}

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/InternalTopicClient.jvm.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/InternalTopicClient.jvm.kt
@@ -1,0 +1,55 @@
+package software.momento.kotlin.sdk.internal
+
+import grpc.cache_client.pubsub._PublishRequest
+import grpc.cache_client.pubsub._TopicValue
+import io.grpc.Metadata
+import software.momento.kotlin.sdk.auth.CredentialProvider
+import software.momento.kotlin.sdk.config.TopicConfiguration
+import software.momento.kotlin.sdk.exceptions.CacheServiceExceptionMapper
+import software.momento.kotlin.sdk.responses.topic.TopicPublishResponse
+import java.io.Closeable
+
+internal actual class InternalTopicClient actual constructor(
+    credentialProvider: CredentialProvider,
+    configuration: TopicConfiguration
+): Closeable {
+    private val stubsManager: TopicGrpcStubsManager
+
+    init {
+        stubsManager = TopicGrpcStubsManager(credentialProvider)
+    }
+
+    internal actual suspend fun publish(
+        cacheName: String, topicName: String, value: String
+    ): TopicPublishResponse {
+        val metadata = metadataWithCache(cacheName)
+
+        val request = _PublishRequest.newBuilder()
+            .setCacheName(cacheName)
+            .setTopic(topicName)
+            .setValue(_TopicValue.newBuilder().setText(value).build())
+            .build()
+
+        try {
+            stubsManager.stub.publish(request, metadata)
+        } catch (e: Exception) {
+            return TopicPublishResponse.Error(CacheServiceExceptionMapper.convert(e, metadata))
+        }
+
+        return TopicPublishResponse.Success
+    }
+
+    companion object {
+        private val CACHE_NAME_KEY = Metadata.Key.of("cache", Metadata.ASCII_STRING_MARSHALLER)
+
+        fun metadataWithCache(cacheName: String): Metadata {
+            val metadata = Metadata()
+            metadata.put(CACHE_NAME_KEY, cacheName)
+            return metadata
+        }
+    }
+
+    override fun close() {
+        stubsManager.close()
+    }
+}

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
@@ -1,0 +1,62 @@
+package software.momento.kotlin.sdk.internal
+
+import grpc.cache_client.pubsub.PubsubGrpcKt
+import io.grpc.ClientInterceptor
+import io.grpc.ManagedChannel
+import io.grpc.ManagedChannelBuilder
+import software.momento.kotlin.sdk.auth.CredentialProvider
+import java.io.Closeable
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.minutes
+
+
+/**
+ * Manager responsible for GRPC channels and stubs for the Control Plane.
+ *
+ *
+ * The business layer, will get request stubs from this layer. This keeps the two layers
+ * independent and any future pooling of channels can happen exclusively in the manager without
+ * impacting the API business logic.
+ */
+internal class TopicGrpcStubsManager(credentialProvider: CredentialProvider) : Closeable {
+    private val channel: ManagedChannel
+    private val futureStub: PubsubGrpcKt.PubsubCoroutineStub
+
+    init {
+        channel = setupConnection(credentialProvider)
+        futureStub = PubsubGrpcKt.PubsubCoroutineStub(channel)
+    }
+
+    val stub: PubsubGrpcKt.PubsubCoroutineStub
+        /**
+         * Returns a stub with appropriate deadlines.
+         *
+         *
+         * Each stub is deliberately decorated with Deadline. Deadlines work differently than timeouts.
+         * When a deadline is set on a stub, it simply means that once the stub is created it must be used
+         * before the deadline expires. Hence, the stub returned from here should never be cached and the
+         * safest behavior is for clients to request a new stub each time.
+         *
+         *
+         * [more information](https://github.com/grpc/grpc-java/issues/1495)
+         */
+        get() = futureStub.withDeadlineAfter(DEADLINE.inWholeSeconds, TimeUnit.SECONDS)
+
+    override fun close() {
+        channel.shutdown()
+    }
+
+    companion object {
+        private val DEADLINE = 1.minutes
+        private fun setupConnection(credentialProvider: CredentialProvider): ManagedChannel {
+            val channelBuilder = ManagedChannelBuilder.forAddress(credentialProvider.cacheEndpoint, 443)
+            channelBuilder.useTransportSecurity()
+            channelBuilder.disableRetry()
+            val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
+            channelBuilder.intercept(clientInterceptors)
+            return channelBuilder.build()
+        }
+    }
+}
+

--- a/src/jvmTest/kotlin/software/momento/kotlin/sdk/JvmExampleTest.kt
+++ b/src/jvmTest/kotlin/software/momento/kotlin/sdk/JvmExampleTest.kt
@@ -1,4 +1,0 @@
-package software.momento.kotlin.sdk
-
-
-class JvmExampleTest

--- a/src/jvmTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
+++ b/src/jvmTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
@@ -1,0 +1,24 @@
+package software.momento.kotlin.sdk
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import software.momento.kotlin.sdk.auth.CredentialProvider
+import software.momento.kotlin.sdk.config.TopicConfiguration
+import software.momento.kotlin.sdk.responses.topic.TopicPublishResponse
+
+
+class TopicClientTest {
+
+    @Test
+    fun testPublish() = runTest {
+        val topicClient = TopicClient(
+            credentialProvider = CredentialProvider.fromEnvVar("TEST_API_KEY"),
+            configuration = TopicConfiguration.Companion.Laptop.Latest
+        )
+        val response = topicClient.publish("cache", "topic", "jvm!")
+        if (response is TopicPublishResponse.Error) {
+            println(response.cause)
+        }
+        assert(response is TopicPublishResponse.Success)
+    }
+}


### PR DESCRIPTION
Add a common expect InternalTopicClient with android and jvm implementations.

Add jvm and android specific TopicClients.

Add a topic publish method.

Testing, especially android testing is still WIP.