### PR TITLE
chore: move prebuilt configurations to a separate object

### DIFF
--- a/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/DataClientTest.kt
+++ b/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/DataClientTest.kt
@@ -1,7 +1,6 @@
 package software.momento.kotlin.sdk
 
 import junit.framework.TestCase.fail
-import software.momento.kotlin.sdk.config.Configuration
 import software.momento.kotlin.sdk.responses.cache.GetResponse
 import software.momento.kotlin.sdk.responses.cache.SetResponse
 import kotlin.time.Duration.Companion.seconds
@@ -13,6 +12,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import software.momento.kotlin.sdk.auth.CredentialProvider
+import software.momento.kotlin.sdk.config.Configurations
 
 @RunWith(AndroidJUnit4::class)
 @LargeTest
@@ -25,7 +25,7 @@ class DataClientTest {
 
         val dataClient = DataClient(
             credentialProvider = CredentialProvider.fromString(apiKey),
-            configuration = Configuration.Companion.Laptop.Latest
+            configuration = Configurations.Laptop.Latest
         )
 
         val setResponse = dataClient.set("cache", "keyKotlin", "val", 60.seconds)

--- a/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/DataClientTest.kt
+++ b/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/DataClientTest.kt
@@ -25,7 +25,7 @@ class DataClientTest {
 
         val dataClient = DataClient(
             credentialProvider = CredentialProvider.fromString(apiKey),
-            configuration = Configurations.Laptop.Latest
+            configuration = Configurations.Laptop.latest
         )
 
         val setResponse = dataClient.set("cache", "keyKotlin", "val", 60.seconds)

--- a/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
+++ b/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
 import software.momento.kotlin.sdk.auth.CredentialProvider
-import software.momento.kotlin.sdk.config.TopicConfiguration
+import software.momento.kotlin.sdk.config.TopicConfigurations
 import software.momento.kotlin.sdk.responses.topic.TopicPublishResponse
 
 @RunWith(AndroidJUnit4::class)
@@ -21,7 +21,7 @@ class TopicClientTest {
 
         val topicClient = TopicClient(
             credentialProvider = CredentialProvider.fromString(apiKey),
-            configuration = TopicConfiguration.Companion.Laptop.Latest
+            configuration = TopicConfigurations.Laptop.Latest
         )
         val response = topicClient.publish("cache", "topic", "android!")
         if (response is TopicPublishResponse.Error) {

--- a/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
+++ b/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
@@ -21,7 +21,7 @@ class TopicClientTest {
 
         val topicClient = TopicClient(
             credentialProvider = CredentialProvider.fromString(apiKey),
-            configuration = TopicConfigurations.Laptop.Latest
+            configuration = TopicConfigurations.Laptop.latest
         )
         val response = topicClient.publish("cache", "topic", "android!")
         if (response is TopicPublishResponse.Error) {

--- a/src/androidUnitTest/kotlin/software/momento/kotlin/sdk/AndroidExampleTest.kt
+++ b/src/androidUnitTest/kotlin/software/momento/kotlin/sdk/AndroidExampleTest.kt
@@ -1,3 +1,0 @@
-package software.momento.kotlin.sdk
-
-class AndroidExampleTest

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/config/Configuration.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/config/Configuration.kt
@@ -1,8 +1,6 @@
 package software.momento.kotlin.sdk.config
 
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * The container for Cache configurables.
@@ -10,99 +8,6 @@ import kotlin.time.Duration.Companion.seconds
  */
 public data class Configuration(val transportStrategy: TransportStrategy) {
 
-    /**
-     * Prebuilt configurations for different environments.
-     */
-    public companion object {
-        /**
-         * Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
-         * and relaxed latency and throughput targets.
-         */
-        public object Laptop {
-            /**
-             * Provides the latest recommended configuration for a dev environment.
-             *
-             * <p>This configuration may change in future releases to take advantage of improvements we
-             * identify for default configurations.
-             *
-             * @return the latest Laptop configuration
-             */
-            public val Latest: Configuration = Configuration(
-                transportStrategy = TransportStrategy(
-                    grpcConfiguration = GrpcConfiguration(
-                        timeout = 15.seconds
-                    )
-                )
-            )
-        }
-
-        /**
-         * Provides defaults suitable for a medium-to-high-latency mobile environment. Permissive timeouts
-         * and relaxed latency and throughput targets.
-         */
-        public object Mobile {
-            /**
-             * Provides the latest recommended configuration for a mobile environment.
-             *
-             * <p>This configuration may change in future releases to take advantage of improvements we
-             * identify for default configurations.
-             *
-             * @return the latest Mobile configuration
-             */
-            public val Latest: Configuration = Configuration(
-                transportStrategy = TransportStrategy(
-                    grpcConfiguration = GrpcConfiguration(
-                        timeout = 5.seconds
-                    )
-                )
-            )
-        }
-
-        /**
-         * Provides defaults suitable for an environment where your client is running in the same region
-         * as the Momento service. It has more aggressive timeouts than the Laptop config.
-         */
-        public object InRegion {
-            /**
-             * Provides the latest recommended configuration for an in-region environment.
-             *
-             * <p>This configuration may change in future releases to take advantage of improvements we
-             * identify for default configurations.
-             *
-             * @return the latest in-region configuration
-             */
-            public val Latest: Configuration = Configuration(
-                transportStrategy = TransportStrategy(
-                    grpcConfiguration = GrpcConfiguration(
-                        timeout = 1100.milliseconds
-                    )
-                )
-            )
-
-            /**
-             * This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
-             * some throughput to achieve this. Use this configuration if low latency is more important in
-             * your application than cache availability.
-             */
-            public object LowLatency {
-                /**
-                 * Provides the latest recommended configuration for a low-latency in-region environment.
-                 *
-                 * <p>This configuration may change in future releases to take advantage of improvements we
-                 * identify for default configurations.
-                 *
-                 * @return the latest low-latency configuration
-                 */
-                public val Latest: Configuration = Configuration(
-                    transportStrategy = TransportStrategy(
-                        grpcConfiguration = GrpcConfiguration(
-                            timeout = 500.milliseconds
-                        )
-                    )
-                )
-            }
-        }
-    }
 
     /**
      * Creates a new configuration with the specified gRPC timeout.

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/config/Configurations.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/config/Configurations.kt
@@ -1,0 +1,99 @@
+package software.momento.kotlin.sdk.config
+
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Prebuilt configurations for different environments.
+ */
+public object Configurations {
+
+    /**
+     * Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
+     * and relaxed latency and throughput targets.
+     */
+    public object Laptop {
+        /**
+         * Provides the latest recommended configuration for a dev environment.
+         *
+         * <p>This configuration may change in future releases to take advantage of improvements we
+         * identify for default configurations.
+         *
+         * @return the latest Laptop configuration
+         */
+        public val Latest: Configuration = Configuration(
+            transportStrategy = TransportStrategy(
+                grpcConfiguration = GrpcConfiguration(
+                    timeout = 15.seconds
+                )
+            )
+        )
+    }
+
+    /**
+     * Provides defaults suitable for a medium-to-high-latency mobile environment. Permissive timeouts
+     * and relaxed latency and throughput targets.
+     */
+    public object Mobile {
+        /**
+         * Provides the latest recommended configuration for a mobile environment.
+         *
+         * <p>This configuration may change in future releases to take advantage of improvements we
+         * identify for default configurations.
+         *
+         * @return the latest Mobile configuration
+         */
+        public val Latest: Configuration = Configuration(
+            transportStrategy = TransportStrategy(
+                grpcConfiguration = GrpcConfiguration(
+                    timeout = 5.seconds
+                )
+            )
+        )
+    }
+
+    /**
+     * Provides defaults suitable for an environment where your client is running in the same region
+     * as the Momento service. It has more aggressive timeouts than the Laptop config.
+     */
+    public object InRegion {
+        /**
+         * Provides the latest recommended configuration for an in-region environment.
+         *
+         * <p>This configuration may change in future releases to take advantage of improvements we
+         * identify for default configurations.
+         *
+         * @return the latest in-region configuration
+         */
+        public val Latest: Configuration = Configuration(
+            transportStrategy = TransportStrategy(
+                grpcConfiguration = GrpcConfiguration(
+                    timeout = 1100.milliseconds
+                )
+            )
+        )
+
+        /**
+         * This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
+         * some throughput to achieve this. Use this configuration if low latency is more important in
+         * your application than cache availability.
+         */
+        public object LowLatency {
+            /**
+             * Provides the latest recommended configuration for a low-latency in-region environment.
+             *
+             * <p>This configuration may change in future releases to take advantage of improvements we
+             * identify for default configurations.
+             *
+             * @return the latest low-latency configuration
+             */
+            public val Latest: Configuration = Configuration(
+                transportStrategy = TransportStrategy(
+                    grpcConfiguration = GrpcConfiguration(
+                        timeout = 500.milliseconds
+                    )
+                )
+            )
+        }
+    }
+}

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/config/Configurations.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/config/Configurations.kt
@@ -21,7 +21,7 @@ public object Configurations {
          *
          * @return the latest Laptop configuration
          */
-        public val Latest: Configuration = Configuration(
+        public val latest: Configuration = Configuration(
             transportStrategy = TransportStrategy(
                 grpcConfiguration = GrpcConfiguration(
                     timeout = 15.seconds
@@ -43,7 +43,7 @@ public object Configurations {
          *
          * @return the latest Mobile configuration
          */
-        public val Latest: Configuration = Configuration(
+        public val latest: Configuration = Configuration(
             transportStrategy = TransportStrategy(
                 grpcConfiguration = GrpcConfiguration(
                     timeout = 5.seconds
@@ -65,7 +65,7 @@ public object Configurations {
          *
          * @return the latest in-region configuration
          */
-        public val Latest: Configuration = Configuration(
+        public val latest: Configuration = Configuration(
             transportStrategy = TransportStrategy(
                 grpcConfiguration = GrpcConfiguration(
                     timeout = 1100.milliseconds
@@ -87,7 +87,7 @@ public object Configurations {
              *
              * @return the latest low-latency configuration
              */
-            public val Latest: Configuration = Configuration(
+            public val latest: Configuration = Configuration(
                 transportStrategy = TransportStrategy(
                     grpcConfiguration = GrpcConfiguration(
                         timeout = 500.milliseconds

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/config/TopicConfiguration.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/config/TopicConfiguration.kt
@@ -1,108 +1,12 @@
 package software.momento.kotlin.sdk.config
 
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
 /**
  * The container for Topic configurables.
  * @param transportStrategy Configuration for network tunables.
  */
 public data class TopicConfiguration(val transportStrategy: TopicTransportStrategy) {
-
-    /**
-     * Prebuilt configurations for different environments.
-     */
-    public companion object {
-        /**
-         * Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
-         * and relaxed latency and throughput targets.
-         */
-        public object Laptop {
-            /**
-             * Provides the latest recommended configuration for a dev environment.
-             *
-             * <p>This configuration may change in future releases to take advantage of improvements we
-             * identify for default configurations.
-             *
-             * @return the latest Laptop configuration
-             */
-            public val Latest: TopicConfiguration = TopicConfiguration(
-                transportStrategy = TopicTransportStrategy(
-                    grpcConfiguration = GrpcConfiguration(
-                        timeout = 15.seconds
-                    )
-                )
-            )
-        }
-
-        /**
-         * Provides defaults suitable for a medium-to-high-latency mobile environment. Permissive timeouts
-         * and relaxed latency and throughput targets.
-         */
-        public object Mobile {
-            /**
-             * Provides the latest recommended configuration for a mobile environment.
-             *
-             * <p>This configuration may change in future releases to take advantage of improvements we
-             * identify for default configurations.
-             *
-             * @return the latest Mobile configuration
-             */
-            public val Latest: TopicConfiguration = TopicConfiguration(
-                transportStrategy = TopicTransportStrategy(
-                    grpcConfiguration = GrpcConfiguration(
-                        timeout = 5.seconds
-                    )
-                )
-            )
-        }
-
-        /**
-         * Provides defaults suitable for an environment where your client is running in the same region
-         * as the Momento service. It has more aggressive timeouts than the Laptop config.
-         */
-        public object InRegion {
-            /**
-             * Provides the latest recommended configuration for an in-region environment.
-             *
-             * <p>This configuration may change in future releases to take advantage of improvements we
-             * identify for default configurations.
-             *
-             * @return the latest in-region configuration
-             */
-            public val Latest: TopicConfiguration = TopicConfiguration(
-                transportStrategy = TopicTransportStrategy(
-                    grpcConfiguration = GrpcConfiguration(
-                        timeout = 1100.milliseconds
-                    )
-                )
-            )
-
-            /**
-             * This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
-             * some throughput to achieve this. Use this configuration if low latency is more important in
-             * your application than cache availability.
-             */
-            public object LowLatency {
-                /**
-                 * Provides the latest recommended configuration for a low-latency in-region environment.
-                 *
-                 * <p>This configuration may change in future releases to take advantage of improvements we
-                 * identify for default configurations.
-                 *
-                 * @return the latest low-latency configuration
-                 */
-                public val Latest: TopicConfiguration = TopicConfiguration(
-                    transportStrategy = TopicTransportStrategy(
-                        grpcConfiguration = GrpcConfiguration(
-                            timeout = 500.milliseconds
-                        )
-                    )
-                )
-            }
-        }
-    }
 
     /**
      * Creates a new topic configuration with the specified gRPC timeout.

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/config/TopicConfigurations.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/config/TopicConfigurations.kt
@@ -21,7 +21,7 @@ public object TopicConfigurations {
          *
          * @return the latest Laptop configuration
          */
-        public val Latest: TopicConfiguration = TopicConfiguration(
+        public val latest: TopicConfiguration = TopicConfiguration(
             transportStrategy = TopicTransportStrategy(
                 grpcConfiguration = GrpcConfiguration(
                     timeout = 15.seconds
@@ -43,7 +43,7 @@ public object TopicConfigurations {
          *
          * @return the latest Mobile configuration
          */
-        public val Latest: TopicConfiguration = TopicConfiguration(
+        public val latest: TopicConfiguration = TopicConfiguration(
             transportStrategy = TopicTransportStrategy(
                 grpcConfiguration = GrpcConfiguration(
                     timeout = 5.seconds
@@ -65,7 +65,7 @@ public object TopicConfigurations {
          *
          * @return the latest in-region configuration
          */
-        public val Latest: TopicConfiguration = TopicConfiguration(
+        public val latest: TopicConfiguration = TopicConfiguration(
             transportStrategy = TopicTransportStrategy(
                 grpcConfiguration = GrpcConfiguration(
                     timeout = 1100.milliseconds
@@ -87,7 +87,7 @@ public object TopicConfigurations {
              *
              * @return the latest low-latency configuration
              */
-            public val Latest: TopicConfiguration = TopicConfiguration(
+            public val latest: TopicConfiguration = TopicConfiguration(
                 transportStrategy = TopicTransportStrategy(
                     grpcConfiguration = GrpcConfiguration(
                         timeout = 500.milliseconds

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/config/TopicConfigurations.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/config/TopicConfigurations.kt
@@ -1,0 +1,99 @@
+package software.momento.kotlin.sdk.config
+
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Prebuilt configurations for different environments.
+ */
+public object TopicConfigurations {
+
+    /**
+     * Provides defaults suitable for a medium-to-high-latency dev environment. Permissive timeouts
+     * and relaxed latency and throughput targets.
+     */
+    public object Laptop {
+        /**
+         * Provides the latest recommended configuration for a dev environment.
+         *
+         * <p>This configuration may change in future releases to take advantage of improvements we
+         * identify for default configurations.
+         *
+         * @return the latest Laptop configuration
+         */
+        public val Latest: TopicConfiguration = TopicConfiguration(
+            transportStrategy = TopicTransportStrategy(
+                grpcConfiguration = GrpcConfiguration(
+                    timeout = 15.seconds
+                )
+            )
+        )
+    }
+
+    /**
+     * Provides defaults suitable for a medium-to-high-latency mobile environment. Permissive timeouts
+     * and relaxed latency and throughput targets.
+     */
+    public object Mobile {
+        /**
+         * Provides the latest recommended configuration for a mobile environment.
+         *
+         * <p>This configuration may change in future releases to take advantage of improvements we
+         * identify for default configurations.
+         *
+         * @return the latest Mobile configuration
+         */
+        public val Latest: TopicConfiguration = TopicConfiguration(
+            transportStrategy = TopicTransportStrategy(
+                grpcConfiguration = GrpcConfiguration(
+                    timeout = 5.seconds
+                )
+            )
+        )
+    }
+
+    /**
+     * Provides defaults suitable for an environment where your client is running in the same region
+     * as the Momento service. It has more aggressive timeouts than the Laptop config.
+     */
+    public object InRegion {
+        /**
+         * Provides the latest recommended configuration for an in-region environment.
+         *
+         * <p>This configuration may change in future releases to take advantage of improvements we
+         * identify for default configurations.
+         *
+         * @return the latest in-region configuration
+         */
+        public val Latest: TopicConfiguration = TopicConfiguration(
+            transportStrategy = TopicTransportStrategy(
+                grpcConfiguration = GrpcConfiguration(
+                    timeout = 1100.milliseconds
+                )
+            )
+        )
+
+        /**
+         * This config prioritizes keeping p99.9 latencies as low as possible, potentially sacrificing
+         * some throughput to achieve this. Use this configuration if low latency is more important in
+         * your application than cache availability.
+         */
+        public object LowLatency {
+            /**
+             * Provides the latest recommended configuration for a low-latency in-region environment.
+             *
+             * <p>This configuration may change in future releases to take advantage of improvements we
+             * identify for default configurations.
+             *
+             * @return the latest low-latency configuration
+             */
+            public val Latest: TopicConfiguration = TopicConfiguration(
+                transportStrategy = TopicTransportStrategy(
+                    grpcConfiguration = GrpcConfiguration(
+                        timeout = 500.milliseconds
+                    )
+                )
+            )
+        }
+    }
+}

--- a/src/commonTest/kotlin/software/momento/kotlin/sdk/CommonExampleTest.kt
+++ b/src/commonTest/kotlin/software/momento/kotlin/sdk/CommonExampleTest.kt
@@ -1,2 +1,0 @@
-package software.momento.kotlin.sdk
-class CommonExampleTest

--- a/src/jvmTest/kotlin/software/momento/kotlin/sdk/DataClientTest.kt
+++ b/src/jvmTest/kotlin/software/momento/kotlin/sdk/DataClientTest.kt
@@ -3,7 +3,7 @@ package software.momento.kotlin.sdk
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import software.momento.kotlin.sdk.auth.CredentialProvider
-import software.momento.kotlin.sdk.config.Configuration
+import software.momento.kotlin.sdk.config.Configurations
 import software.momento.kotlin.sdk.responses.cache.GetResponse
 import software.momento.kotlin.sdk.responses.cache.SetResponse
 import kotlin.test.fail
@@ -16,7 +16,7 @@ class DataClientTest {
 
         val dataClient = DataClient(
             credentialProvider = CredentialProvider.fromEnvVar("TEST_API_KEY"),
-            configuration = Configuration.Companion.Laptop.Latest
+            configuration = Configurations.Laptop.Latest
         )
 
         val setResponse = dataClient.set("cache", "keyKotlin", "val", 60.seconds)

--- a/src/jvmTest/kotlin/software/momento/kotlin/sdk/DataClientTest.kt
+++ b/src/jvmTest/kotlin/software/momento/kotlin/sdk/DataClientTest.kt
@@ -16,7 +16,7 @@ class DataClientTest {
 
         val dataClient = DataClient(
             credentialProvider = CredentialProvider.fromEnvVar("TEST_API_KEY"),
-            configuration = Configurations.Laptop.Latest
+            configuration = Configurations.Laptop.latest
         )
 
         val setResponse = dataClient.set("cache", "keyKotlin", "val", 60.seconds)

--- a/src/jvmTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
+++ b/src/jvmTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
@@ -13,7 +13,7 @@ class TopicClientTest {
     fun testPublish() = runTest {
         val topicClient = TopicClient(
             credentialProvider = CredentialProvider.fromEnvVar("TEST_API_KEY"),
-            configuration = TopicConfigurations.Laptop.Latest
+            configuration = TopicConfigurations.Laptop.latest
         )
         val response = topicClient.publish("cache", "topic", "jvm!")
         if (response is TopicPublishResponse.Error) {

--- a/src/jvmTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
+++ b/src/jvmTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
@@ -3,7 +3,7 @@ package software.momento.kotlin.sdk
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import software.momento.kotlin.sdk.auth.CredentialProvider
-import software.momento.kotlin.sdk.config.TopicConfiguration
+import software.momento.kotlin.sdk.config.TopicConfigurations
 import software.momento.kotlin.sdk.responses.topic.TopicPublishResponse
 
 
@@ -13,7 +13,7 @@ class TopicClientTest {
     fun testPublish() = runTest {
         val topicClient = TopicClient(
             credentialProvider = CredentialProvider.fromEnvVar("TEST_API_KEY"),
-            configuration = TopicConfiguration.Companion.Laptop.Latest
+            configuration = TopicConfigurations.Laptop.Latest
         )
         val response = topicClient.publish("cache", "topic", "jvm!")
         if (response is TopicPublishResponse.Error) {


### PR DESCRIPTION
Move the prebuilt cache and topic client configurations to their own Configurations objects, so they don't need to be referenced using 'companion'.

Remove unused example test classes.