### PR TITLE
fix: Add alreadyExists to the create cache response

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,7 @@ kotlin {
         }
         val androidInstrumentedTest by getting {
             dependencies {
+                implementation(kotlin("test-junit"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
                 implementation("androidx.test.ext:junit:1.1.5")
                 implementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/CacheClientControlTest.kt
+++ b/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/CacheClientControlTest.kt
@@ -1,0 +1,47 @@
+package software.momento.kotlin.sdk
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import kotlinx.coroutines.test.runTest
+import org.junit.runner.RunWith
+import software.momento.kotlin.sdk.exceptions.NotFoundException
+import software.momento.kotlin.sdk.responses.cache.control.CacheCreateResponse
+import software.momento.kotlin.sdk.responses.cache.control.CacheDeleteResponse
+import java.util.*
+import kotlin.test.Test
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class CacheClientControlTest: BaseAndroidTestClass() {
+
+    @Test
+    fun createCacheFailsWithInvalidCacheName() = runTest {
+        val response = cacheClient.createCache("")
+        assert(response is CacheCreateResponse.Error)
+    }
+
+    @Test
+    fun deleteCacheFailsWithInvalidCacheName() = runTest {
+        val response = cacheClient.deleteCache("")
+        assert(response is CacheDeleteResponse.Error)
+    }
+
+    @Test
+    fun createDeleteCacheHappyPath() = runTest {
+        val cacheName = "kotlin-android-create-delete-${UUID.randomUUID()}"
+
+        try {
+            var createResponse = cacheClient.createCache(cacheName)
+            assert(createResponse is CacheCreateResponse.Success)
+
+            createResponse = cacheClient.createCache(cacheName)
+            assert(createResponse is CacheCreateResponse.AlreadyExists)
+        } finally {
+            var deleteResponse = cacheClient.deleteCache(cacheName)
+            assert(deleteResponse is CacheDeleteResponse.Success)
+
+            deleteResponse = cacheClient.deleteCache(cacheName)
+            assert((deleteResponse as CacheDeleteResponse.Error).cause is NotFoundException)
+        }
+    }
+}

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/InternalControlClient.android.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/InternalControlClient.android.kt
@@ -5,6 +5,7 @@ import grpc.control_client._DeleteCacheRequest
 import software.momento.kotlin.sdk.auth.CredentialProvider
 import software.momento.kotlin.sdk.config.Configuration
 import software.momento.kotlin.sdk.exceptions.CacheServiceExceptionMapper
+import software.momento.kotlin.sdk.exceptions.MomentoErrorCode
 import software.momento.kotlin.sdk.responses.cache.control.CacheCreateResponse
 import software.momento.kotlin.sdk.responses.cache.control.CacheDeleteResponse
 import software.momento.kotlin.sdk.internal.utils.ValidationUtils
@@ -38,7 +39,11 @@ internal actual class InternalControlClient actual constructor(
         }.fold(onSuccess = {
             CacheCreateResponse.Success
         }, onFailure = { e ->
-            CacheCreateResponse.Error(CacheServiceExceptionMapper.convert(e, metadata))
+            val sdkException = CacheServiceExceptionMapper.convert(e, metadata)
+            when (sdkException.errorCode) {
+                MomentoErrorCode.ALREADY_EXISTS_ERROR -> CacheCreateResponse.AlreadyExists
+                else -> CacheCreateResponse.Error(sdkException)
+            }
         })
     }
 

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/exceptions/CacheServiceExceptionMapper.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/exceptions/CacheServiceExceptionMapper.kt
@@ -25,15 +25,12 @@ public object CacheServiceExceptionMapper {
         return when (e) {
             is IllegalArgumentException -> InvalidArgumentException(e.message)
             is SdkException -> e
-            is StatusException -> {
-                val statusCode = e.status.code
-                val errorDetails = MomentoTransportErrorDetails(
-                    MomentoGrpcErrorDetails(statusCode, e.message!!, metadata)
-                )
-                convertStatusException(e, errorDetails, statusCode)
-            }
-            is StatusRuntimeException -> {
-                val statusCode = e.status.code
+            is StatusException, is StatusRuntimeException -> {
+                val statusCode = when (e) {
+                    is StatusException -> e.status.code
+                    is StatusRuntimeException -> e.status.code
+                    else -> Status.Code.UNKNOWN
+                }
                 val errorDetails = MomentoTransportErrorDetails(
                     MomentoGrpcErrorDetails(statusCode, e.message!!, metadata)
                 )

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/exceptions/CacheServiceExceptionMapper.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/exceptions/CacheServiceExceptionMapper.kt
@@ -2,6 +2,7 @@ package software.momento.kotlin.sdk.exceptions
 
 import io.grpc.Metadata
 import io.grpc.Status
+import io.grpc.StatusException
 import io.grpc.StatusRuntimeException
 import software.momento.kotlin.sdk.internal.MomentoGrpcErrorDetails
 import software.momento.kotlin.sdk.internal.MomentoTransportErrorDetails
@@ -24,36 +25,47 @@ public object CacheServiceExceptionMapper {
         return when (e) {
             is IllegalArgumentException -> InvalidArgumentException(e.message)
             is SdkException -> e
+            is StatusException -> {
+                val statusCode = e.status.code
+                val errorDetails = MomentoTransportErrorDetails(
+                    MomentoGrpcErrorDetails(statusCode, e.message!!, metadata)
+                )
+                convertStatusException(e, errorDetails, statusCode)
+            }
             is StatusRuntimeException -> {
                 val statusCode = e.status.code
                 val errorDetails = MomentoTransportErrorDetails(
                     MomentoGrpcErrorDetails(statusCode, e.message!!, metadata)
                 )
-                when (statusCode) {
-                    Status.Code.INVALID_ARGUMENT, Status.Code.UNIMPLEMENTED,
-                    Status.Code.OUT_OF_RANGE, Status.Code.FAILED_PRECONDITION -> BadRequestException(
-                        e, errorDetails
-                    )
-                    Status.Code.CANCELLED -> CancellationException(e, errorDetails)
-                    Status.Code.DEADLINE_EXCEEDED -> TimeoutException(e, errorDetails)
-                    Status.Code.PERMISSION_DENIED -> PermissionDeniedException(
-                        e, errorDetails
-                    )
-                    Status.Code.UNAUTHENTICATED -> AuthenticationException(e, errorDetails)
-                    Status.Code.RESOURCE_EXHAUSTED -> LimitExceededException(
-                        e, errorDetails
-                    )
-                    Status.Code.NOT_FOUND -> NotFoundException(e, errorDetails)
-                    Status.Code.ALREADY_EXISTS -> AlreadyExistsException(e, errorDetails)
-                    Status.Code.UNKNOWN -> UnknownServiceException(e, errorDetails)
-                    Status.Code.UNAVAILABLE -> ServerUnavailableException(e, errorDetails)
-                    Status.Code.ABORTED, Status.Code.INTERNAL, Status.Code.DATA_LOSS -> InternalServerException(
-                        e, errorDetails
-                    )
-                    else -> InternalServerException(e, errorDetails)
-                }
+                convertStatusException(e, errorDetails, statusCode)
             }
             else -> UnknownException(SDK_FAILED_TO_PROCESS_THE_REQUEST, e)
+        }
+    }
+
+    private fun convertStatusException(e: Throwable, errorDetails: MomentoTransportErrorDetails, statusCode: Status.Code): SdkException {
+        return when (statusCode) {
+            Status.Code.INVALID_ARGUMENT, Status.Code.UNIMPLEMENTED,
+            Status.Code.OUT_OF_RANGE, Status.Code.FAILED_PRECONDITION -> BadRequestException(
+                e, errorDetails
+            )
+            Status.Code.CANCELLED -> CancellationException(e, errorDetails)
+            Status.Code.DEADLINE_EXCEEDED -> TimeoutException(e, errorDetails)
+            Status.Code.PERMISSION_DENIED -> PermissionDeniedException(
+                e, errorDetails
+            )
+            Status.Code.UNAUTHENTICATED -> AuthenticationException(e, errorDetails)
+            Status.Code.RESOURCE_EXHAUSTED -> LimitExceededException(
+                e, errorDetails
+            )
+            Status.Code.NOT_FOUND -> NotFoundException(e, errorDetails)
+            Status.Code.ALREADY_EXISTS -> AlreadyExistsException(e, errorDetails)
+            Status.Code.UNKNOWN -> UnknownServiceException(e, errorDetails)
+            Status.Code.UNAVAILABLE -> ServerUnavailableException(e, errorDetails)
+            Status.Code.ABORTED, Status.Code.INTERNAL, Status.Code.DATA_LOSS -> InternalServerException(
+                e, errorDetails
+            )
+            else -> InternalServerException(e, errorDetails)
         }
     }
 }

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/responses/cache/control/CacheCreateResponse.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/responses/cache/control/CacheCreateResponse.kt
@@ -5,8 +5,11 @@ import software.momento.kotlin.sdk.exceptions.SdkException
 /** Response for a create cache operation in Kotlin */
 public sealed interface CacheCreateResponse {
 
-    /** A successful create cache operation. */
+    /** A successful create cache operation that created a cache. */
     public object Success : CacheCreateResponse
+
+    /** A no-op create cache operation that occurred because the cache already existed. */
+    public object AlreadyExists : CacheCreateResponse
 
     /**
      * A failed create cache operation. The response itself is an exception, so it can be directly

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/InternalControlClient.jvm.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/InternalControlClient.jvm.kt
@@ -5,6 +5,7 @@ import grpc.control_client._DeleteCacheRequest
 import software.momento.kotlin.sdk.auth.CredentialProvider
 import software.momento.kotlin.sdk.config.Configuration
 import software.momento.kotlin.sdk.exceptions.CacheServiceExceptionMapper
+import software.momento.kotlin.sdk.exceptions.MomentoErrorCode
 import software.momento.kotlin.sdk.responses.cache.control.CacheCreateResponse
 import software.momento.kotlin.sdk.responses.cache.control.CacheDeleteResponse
 import software.momento.kotlin.sdk.internal.utils.ValidationUtils
@@ -37,7 +38,11 @@ internal actual class InternalControlClient actual constructor(
         }.fold(onSuccess = {
             CacheCreateResponse.Success
         }, onFailure = { e ->
-            CacheCreateResponse.Error(CacheServiceExceptionMapper.convert(e, metadata))
+            val sdkException = CacheServiceExceptionMapper.convert(e, metadata)
+            when (sdkException.errorCode) {
+                MomentoErrorCode.ALREADY_EXISTS_ERROR -> CacheCreateResponse.AlreadyExists
+                else -> CacheCreateResponse.Error(sdkException)
+            }
         })
     }
 

--- a/src/jvmTest/kotlin/software/momento/kotlin/sdk/CacheClientControlTest.kt
+++ b/src/jvmTest/kotlin/software/momento/kotlin/sdk/CacheClientControlTest.kt
@@ -1,0 +1,42 @@
+package software.momento.kotlin.sdk
+
+import kotlinx.coroutines.test.runTest
+import software.momento.kotlin.sdk.exceptions.NotFoundException
+import software.momento.kotlin.sdk.responses.cache.control.CacheCreateResponse
+import software.momento.kotlin.sdk.responses.cache.control.CacheDeleteResponse
+import java.util.*
+import kotlin.test.Test
+
+class CacheClientControlTest: BaseJvmTestClass() {
+
+    @Test
+    fun createCacheFailsWithInvalidCacheName() = runTest {
+        val response = cacheClient.createCache("")
+        assert(response is CacheCreateResponse.Error)
+    }
+
+    @Test
+    fun deleteCacheFailsWithInvalidCacheName() = runTest {
+        val response = cacheClient.deleteCache("")
+        assert(response is CacheDeleteResponse.Error)
+    }
+
+    @Test
+    fun createDeleteCacheHappyPath() = runTest {
+        val cacheName = "kotlin-jvm-create-delete-${UUID.randomUUID()}"
+
+        try {
+            var createResponse = cacheClient.createCache(cacheName)
+            assert(createResponse is CacheCreateResponse.Success)
+
+            createResponse = cacheClient.createCache(cacheName)
+            assert(createResponse is CacheCreateResponse.AlreadyExists)
+        } finally {
+            var deleteResponse = cacheClient.deleteCache(cacheName)
+            assert(deleteResponse is CacheDeleteResponse.Success)
+
+            deleteResponse = cacheClient.deleteCache(cacheName)
+            assert((deleteResponse as CacheDeleteResponse.Error).cause is NotFoundException)
+        }
+    }
+}


### PR DESCRIPTION
Add an AlreadyExists type to CacheCreateResponse to cover the case of a cache with the same name already existing.

Correctly convert StatusException as well as StatusRuntimeException to correct the error returned when deleting a non-existent cache.