### PR TITLE
chore: switch to released version of client protos

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@ version = "0.1.0-SNAPSHOT"
 repositories {
     mavenCentral()
     google()
-    maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
 }
 
 android {
@@ -64,7 +63,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-jdk8"))
-                implementation("software.momento.kotlin:client-protos-jvm:0.1.0-SNAPSHOT")
+                implementation("software.momento.kotlin:client-protos-jvm:0.100.0")
                 runtimeOnly("io.grpc:grpc-netty:1.57.2")
             }
         }
@@ -75,7 +74,7 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                implementation("software.momento.kotlin:client-protos-android:0.1.0-SNAPSHOT")
+                implementation("software.momento.kotlin:client-protos-android:0.100.0")
                 runtimeOnly("io.grpc:grpc-okhttp:1.57.2")
             }
         }


### PR DESCRIPTION
Release-As: 0.5.0