### PR TITLE
fix: workaround for multiplatform/gradle 8 signing bug

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -164,11 +164,9 @@ if (signingKey != null) {
     }
 }
 
-afterEvaluate {
-    tasks.named("publishAndroidReleasePublicationToSonatypeRepository").configure {
-        mustRunAfter(":signJvmPublication", ":signAndroidReleasePublication")
-    }
-    tasks.named("publishJvmPublicationToSonatypeRepository").configure {
-        mustRunAfter(":signJvmPublication", ":signAndroidReleasePublication")
-    }
+// Fix Gradle error about signing tasks using publishing task outputs without explicit dependencies
+// https://github.com/gradle/gradle/issues/26091
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    val signingTasks = tasks.withType<Sign>()
+    mustRunAfter(signingTasks)
 }


### PR DESCRIPTION
Add a workaround for a bug between kotlin multiplatform and gradle 8 that stops signing from working correctly when there are multiple publication targets.