### PR TITLE
feat: add runtime version metadata to the first Momento call

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,10 @@ jobs:
         arguments: clean build
 
   android:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        api-level: [ 23 ]
+        api-level: [ 26 ]
     env:
       TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: kotlin-integration-test-android-ci-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,8 +45,7 @@ jobs:
         arguments: clean build
 
   android:
-    # The Android emulator only has hardware acceleration on macOS.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         api-level: [ 23 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         with:
           arguments: clean build -x jvmTest -x testDebugUnitTest -x testReleaseUnitTest
 
+      # Required for hardware accelerated Android emulation on linux
+      # See https://github.com/ReactiveCircus/android-emulator-runner
       - name: Enable KVM
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
   android:
     # The Android emulator only has hardware acceleration on macOS.
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         api-level: [ 23 ]
@@ -71,6 +71,12 @@ jobs:
         uses: gradle/gradle-build-action@v2.11.1
         with:
           arguments: clean build -x jvmTest -x testDebugUnitTest -x testReleaseUnitTest
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
 
       - name: run tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
         val jvmMain by getting {
             dependencies {
                 implementation(kotlin("stdlib-jdk8"))
-                implementation("software.momento.kotlin:client-protos-jvm:0.100.0")
+                implementation("software.momento.kotlin:client-protos-jvm:0.114.0")
                 runtimeOnly("io.grpc:grpc-netty:1.57.2")
             }
         }
@@ -74,7 +74,7 @@ kotlin {
         }
         val androidMain by getting {
             dependencies {
-                implementation("software.momento.kotlin:client-protos-android:0.100.0")
+                implementation("software.momento.kotlin:client-protos-android:0.114.0")
                 runtimeOnly("io.grpc:grpc-okhttp:1.57.2")
             }
         }
@@ -88,8 +88,8 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-junit"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
-                implementation("androidx.test.ext:junit:1.1.5")
-                implementation("androidx.test.espresso:espresso-core:3.5.1")
+                implementation("androidx.test.ext:junit:1.2.1")
+                implementation("androidx.test.espresso:espresso-core:3.6.1")
             }
         }
     }

--- a/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/CacheClientScalarTest.kt
+++ b/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/CacheClientScalarTest.kt
@@ -38,19 +38,19 @@ class CacheClientScalarTest: BaseAndroidTestClass() {
         val value = "cache-value"
 
         var getResponse = cacheClient.get(cacheName, key)
-        assert(getResponse is GetResponse.Miss)
+        assert(getResponse is GetResponse.Miss) { "expected Miss, got $getResponse" }
 
         val setResponse = cacheClient.set(cacheName, key, value)
-        assert(setResponse is SetResponse.Success)
+        assert(setResponse is SetResponse.Success) { "expected Success, got $setResponse" }
 
         getResponse = cacheClient.get(cacheName, key)
         assert((getResponse as GetResponse.Hit).value == value)
 
         val deleteResponse = cacheClient.delete(cacheName, key)
-        assert(deleteResponse is DeleteResponse.Success)
+        assert(deleteResponse is DeleteResponse.Success) { "expected Success, got $deleteResponse" }
 
         getResponse = cacheClient.get(cacheName, key)
-        assert(getResponse is GetResponse.Miss)
+        assert(getResponse is GetResponse.Miss) { "expected Miss, got $getResponse" }
     }
 
     @Test
@@ -59,18 +59,18 @@ class CacheClientScalarTest: BaseAndroidTestClass() {
         val value = "cache-value".encodeToByteArray()
 
         var getResponse = cacheClient.get(cacheName, key)
-        assert(getResponse is GetResponse.Miss)
+        assert(getResponse is GetResponse.Miss) { "expected Miss, got $getResponse" }
 
         val setResponse = cacheClient.set(cacheName, key, value)
-        assert(setResponse is SetResponse.Success)
+        assert(setResponse is SetResponse.Success) { "expected Miss, got $setResponse" }
 
         getResponse = cacheClient.get(cacheName, key)
         assert((getResponse as GetResponse.Hit).valueByteArray.contentEquals(value))
 
         val deleteResponse = cacheClient.delete(cacheName, key)
-        assert(deleteResponse is DeleteResponse.Success)
+        assert(deleteResponse is DeleteResponse.Success) { "expected Success, got $getResponse" }
 
         getResponse = cacheClient.get(cacheName, key)
-        assert(getResponse is GetResponse.Miss)
+        assert(getResponse is GetResponse.Miss) { "expected Miss, got $getResponse" }
     }
 }

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/ControlGrpcStubsManager.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/ControlGrpcStubsManager.kt
@@ -43,7 +43,7 @@ internal class ControlGrpcStubsManager(credentialProvider: CredentialProvider) :
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor("android", credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/ControlGrpcStubsManager.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/ControlGrpcStubsManager.kt
@@ -17,6 +17,7 @@ internal class ControlGrpcStubsManager(credentialProvider: CredentialProvider) :
         channel = setupConnection(credentialProvider)
         futureStub = ScsControlGrpcKt.ScsControlCoroutineStub(channel)
     }
+
     val stub: ScsControlGrpcKt.ScsControlCoroutineStub
         /**
          * Returns a stub with appropriate deadlines.
@@ -43,7 +44,7 @@ internal class ControlGrpcStubsManager(credentialProvider: CredentialProvider) :
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey, "cache"))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/DataGrpcStubsManager.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/DataGrpcStubsManager.kt
@@ -11,7 +11,8 @@ import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.minutes
 
-internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, configuration: GrpcConfiguration) : Closeable {
+internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, configuration: GrpcConfiguration) :
+    Closeable {
     private val deadline: Duration
     private val channel: ManagedChannel
     private val futureStub: ScsGrpcKt.ScsCoroutineStub
@@ -21,6 +22,7 @@ internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, conf
         channel = setupConnection(credentialProvider)
         futureStub = ScsGrpcKt.ScsCoroutineStub(channel)
     }
+
     val stub: ScsGrpcKt.ScsCoroutineStub
         /**
          * Returns a stub with appropriate deadlines.
@@ -47,7 +49,7 @@ internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, conf
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey, "cache"))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/DataGrpcStubsManager.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/DataGrpcStubsManager.kt
@@ -47,7 +47,7 @@ internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, conf
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor("android", credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
@@ -59,7 +59,7 @@ internal class TopicGrpcStubsManager(credentialProvider: CredentialProvider) : C
             channelBuilder.keepAliveTimeout(5, TimeUnit.SECONDS)
             channelBuilder.keepAliveWithoutCalls(true)
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey, "cache"))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
@@ -59,7 +59,7 @@ internal class TopicGrpcStubsManager(credentialProvider: CredentialProvider) : C
             channelBuilder.keepAliveTimeout(5, TimeUnit.SECONDS)
             channelBuilder.keepAliveWithoutCalls(true)
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor("android", credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.android.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.android.kt
@@ -3,11 +3,6 @@ package software.momento.kotlin.sdk.internal
 import android.os.Build
 
 internal actual class PlatformInfo {
-    internal actual val sdkVersion: String
-        get() {
-            val version = this.javaClass.getPackage()?.implementationVersion ?:  "unknown"
-            return "kotlin-android:$version"
-        }
     internal actual val runtimeVersion: String
         get() {
             val kotlinVersion = KotlinVersion.CURRENT
@@ -16,4 +11,9 @@ internal actual class PlatformInfo {
             val manufacturer = Build.MANUFACTURER
             return "Android $androidVersion, Kotlin $kotlinVersion, $manufacturer $deviceModel"
         }
+
+    internal actual fun getSdkVersion(clientType: String): String {
+        val version = this.javaClass.getPackage()?.implementationVersion ?: "unknown"
+        return "kotlin-android:$clientType:$version"
+    }
 }

--- a/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.android.kt
+++ b/src/androidMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.android.kt
@@ -1,0 +1,19 @@
+package software.momento.kotlin.sdk.internal
+
+import android.os.Build
+
+internal actual class PlatformInfo {
+    internal actual val sdkVersion: String
+        get() {
+            val version = this.javaClass.getPackage()?.implementationVersion ?:  "unknown"
+            return "kotlin-android:$version"
+        }
+    internal actual val runtimeVersion: String
+        get() {
+            val kotlinVersion = KotlinVersion.CURRENT
+            val androidVersion = Build.VERSION.RELEASE
+            val deviceModel = Build.MODEL
+            val manufacturer = Build.MANUFACTURER
+            return "Android $androidVersion, Kotlin $kotlinVersion, $manufacturer $deviceModel"
+        }
+}

--- a/src/commonMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.kt
+++ b/src/commonMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.kt
@@ -1,8 +1,9 @@
 package software.momento.kotlin.sdk.internal
 
-import kotlin.jvm.Volatile
+internal class UserHeaderInterceptor(private val tokenValue: String, private val clientType: String) :
+    io.grpc.ClientInterceptor {
+    private var isUserAgentSent = false
 
-internal class UserHeaderInterceptor(private val tokenValue: String) : io.grpc.ClientInterceptor {
     override fun <ReqT, RespT> interceptCall(
         methodDescriptor: io.grpc.MethodDescriptor<ReqT, RespT>,
         callOptions: io.grpc.CallOptions,
@@ -15,7 +16,7 @@ internal class UserHeaderInterceptor(private val tokenValue: String) : io.grpc.C
                 metadata.put(AUTH_HEADER_KEY, tokenValue)
                 if (!isUserAgentSent) {
                     val platformInfo = PlatformInfo()
-                    metadata.put(SDK_AGENT_KEY, platformInfo.sdkVersion)
+                    metadata.put(SDK_AGENT_KEY, platformInfo.getSdkVersion(clientType))
                     metadata.put(RUNTIME_VERSION_KEY, platformInfo.runtimeVersion)
                     isUserAgentSent = true
                 }
@@ -26,18 +27,16 @@ internal class UserHeaderInterceptor(private val tokenValue: String) : io.grpc.C
 
     companion object {
         private val AUTH_HEADER_KEY: io.grpc.Metadata.Key<String> =
-            io.grpc.Metadata.Key.of("Authorization", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
+            io.grpc.Metadata.Key.of("authorization", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
         private val SDK_AGENT_KEY: io.grpc.Metadata.Key<String> =
-            io.grpc.Metadata.Key.of("Agent", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
+            io.grpc.Metadata.Key.of("agent", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
         private val RUNTIME_VERSION_KEY: io.grpc.Metadata.Key<String> =
-            io.grpc.Metadata.Key.of("Runtime-Version", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
-
-        @Volatile
-        private var isUserAgentSent = false
+            io.grpc.Metadata.Key.of("runtime-version", io.grpc.Metadata.ASCII_STRING_MARSHALLER)
     }
 }
 
 internal expect class PlatformInfo() {
-    internal val sdkVersion: String
     internal val runtimeVersion: String
+
+    internal fun getSdkVersion(clientType: String): String
 }

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/ControlGrpcStubsManager.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/ControlGrpcStubsManager.kt
@@ -1,6 +1,5 @@
 package software.momento.kotlin.sdk.internal
 
-import grpc.cache_client.ScsGrpcKt
 import grpc.control_client.ScsControlGrpcKt
 import io.grpc.ClientInterceptor
 import io.grpc.ManagedChannel
@@ -18,6 +17,7 @@ internal class ControlGrpcStubsManager(credentialProvider: CredentialProvider) :
         channel = setupConnection(credentialProvider)
         futureStub = ScsControlGrpcKt.ScsControlCoroutineStub(channel)
     }
+
     val stub: ScsControlGrpcKt.ScsControlCoroutineStub
         /**
          * Returns a stub with appropriate deadlines.
@@ -44,7 +44,7 @@ internal class ControlGrpcStubsManager(credentialProvider: CredentialProvider) :
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey, "cache"))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/ControlGrpcStubsManager.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/ControlGrpcStubsManager.kt
@@ -44,7 +44,7 @@ internal class ControlGrpcStubsManager(credentialProvider: CredentialProvider) :
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor("jvm", credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/DataGrpcStubsManager.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/DataGrpcStubsManager.kt
@@ -46,7 +46,7 @@ internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, conf
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor("jvm", credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/DataGrpcStubsManager.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/DataGrpcStubsManager.kt
@@ -9,9 +9,9 @@ import software.momento.kotlin.sdk.config.GrpcConfiguration
 import java.io.Closeable
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.minutes
 
-internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, configuration: GrpcConfiguration) : Closeable {
+internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, configuration: GrpcConfiguration) :
+    Closeable {
     private val deadline: Duration
     private val channel: ManagedChannel
     private val futureStub: ScsGrpcKt.ScsCoroutineStub
@@ -21,6 +21,7 @@ internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, conf
         channel = setupConnection(credentialProvider)
         futureStub = ScsGrpcKt.ScsCoroutineStub(channel)
     }
+
     val stub: ScsGrpcKt.ScsCoroutineStub
         /**
          * Returns a stub with appropriate deadlines.
@@ -46,7 +47,7 @@ internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, conf
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey, "cache"))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
@@ -59,7 +59,7 @@ internal class TopicGrpcStubsManager(credentialProvider: CredentialProvider) : C
             channelBuilder.keepAliveTimeout(5, TimeUnit.SECONDS)
             channelBuilder.keepAliveWithoutCalls(true)
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor("jvm", credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
@@ -59,7 +59,7 @@ internal class TopicGrpcStubsManager(credentialProvider: CredentialProvider) : C
             channelBuilder.keepAliveTimeout(5, TimeUnit.SECONDS)
             channelBuilder.keepAliveWithoutCalls(true)
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
-            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey))
+            clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey, "topic"))
             channelBuilder.intercept(clientInterceptors)
             return channelBuilder.build()
         }

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.jvm.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.jvm.kt
@@ -1,0 +1,16 @@
+package software.momento.kotlin.sdk.internal
+
+internal actual class PlatformInfo {
+    internal actual val sdkVersion: String
+        get() {
+            val version = this.javaClass.getPackage()?.implementationVersion ?:  "unknown"
+            return "kotlin-jvm:$version"
+        }
+    internal actual val runtimeVersion: String
+        get() {
+            val javaVendor = System.getProperty("java.vendor")
+            val javaVersion = System.getProperty("java.version")
+            val kotlinVersion = KotlinVersion.CURRENT
+            return "$javaVendor:$javaVersion, Kotlin $kotlinVersion"
+        }
+}

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.jvm.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/UserHeaderInterceptor.jvm.kt
@@ -1,11 +1,6 @@
 package software.momento.kotlin.sdk.internal
 
 internal actual class PlatformInfo {
-    internal actual val sdkVersion: String
-        get() {
-            val version = this.javaClass.getPackage()?.implementationVersion ?:  "unknown"
-            return "kotlin-jvm:$version"
-        }
     internal actual val runtimeVersion: String
         get() {
             val javaVendor = System.getProperty("java.vendor")
@@ -13,4 +8,9 @@ internal actual class PlatformInfo {
             val kotlinVersion = KotlinVersion.CURRENT
             return "$javaVendor:$javaVersion, Kotlin $kotlinVersion"
         }
+
+    internal actual fun getSdkVersion(clientType: String): String {
+        val version = this.javaClass.getPackage()?.implementationVersion ?: "unknown"
+        return "kotlin-jvm:$clientType:$version"
+    }
 }


### PR DESCRIPTION
Add a new Runtime-Version key to the metadata of the first Momento call made by a client. It contains JVM or Android-specific version info.

Move the implementation-specific sdk and runtime version logic into an expect class with jvm and android versions.