### PR TITLE
chore: update examples to 0.2.0 and enable automatic releases

### DIFF
--- a/.github/workflows/on-push-to-main-branch.yml
+++ b/.github/workflows/on-push-to-main-branch.yml
@@ -73,6 +73,4 @@ jobs:
           ORG_GRADLE_PROJECT_version: ${{ steps.semrel.outputs.version }}
         uses: gradle/gradle-build-action@v2.11.1
         with:
-#          TODO: automatically release when release process is verified to work
-#          arguments: publishToSonatype closeAndReleaseStagingRepository
-          arguments: publishToSonatype closeSonatypeStagingRepository
+          arguments: publishToSonatype closeAndReleaseStagingRepository

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation("software.momento.kotlin:sdk:0.1.3")
+    implementation("software.momento.kotlin:sdk:0.2.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3")
 }
 


### PR DESCRIPTION
Automatically release after pushing to sonatype instead of pushing but waiting for a manual release.