### PR TITLE
fix: rename TEST_API_KEY to MOMENTO_API_KEY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   jvm:
     runs-on: ubuntu-latest
     env:
-      TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: kotlin-integration-test-jvm-ci-${{ github.sha }}
 
     steps:
@@ -50,7 +50,7 @@ jobs:
       matrix:
         api-level: [ 26 ]
     env:
-      TEST_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
+      MOMENTO_API_KEY: ${{ secrets.ALPHA_TEST_AUTH_TOKEN }}
       TEST_CACHE_NAME: kotlin-integration-test-android-ci-${{ github.sha }}
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ export PATH=$PATH:$ANDROID_HOME/platform-tools
 ## Testing
 ### Intellij
 Android instrumented tests can be run by running them through IntelliJ with the Android plugin or Android Studio.
-The `TEST_API_KEY` must be set in your `.zshrc` or somewhere else IntelliJ can read it when it executes the gradle project. The tests cannot directly read environment variables from the host machine, so `TEST_API_KEY` is read by the gradle project and stored in a test property.
+The `MOMENTO_API_KEY` must be set in your `.zshrc` or somewhere else IntelliJ can read it when it executes the gradle project. The tests cannot directly read environment variables from the host machine, so `MOMENTO_API_KEY` is read by the gradle project and stored in a test property.
 
 ### Command Line
 Android instrumented tests can be run from the command line by first starting an emulator:
@@ -23,4 +23,4 @@ Then run the tests:
 ```bash
 ./gradlew connectedAndroidTest
 ```
-`TEST_API_KEY` must be set for the tests to work.
+`MOMENTO_API_KEY` must be set for the tests to work.

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Momento Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,7 @@ kotlin {
         publishLibraryVariants("release")
     }
     jvm()
-    jvmToolchain(17)
+    jvmToolchain(11)
 
     sourceSets {
         val commonMain by getting {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ android {
     defaultConfig {
         minSdk = 23
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        testInstrumentationRunnerArguments["TestApiKey"] = System.getenv("TEST_API_KEY") ?: "noApiKeySet"
+        testInstrumentationRunnerArguments["MomentoApiKey"] = System.getenv("MOMENTO_API_KEY") ?: "noApiKeySet"
         testInstrumentationRunnerArguments["TestCacheName"] = System.getenv("TEST_CACHE_NAME") ?: "test-android-cache"
     }
 
@@ -43,7 +43,7 @@ kotlin {
         publishLibraryVariants("release")
     }
     jvm()
-    jvmToolchain(11)
+    jvmToolchain(17)
 
     sourceSets {
         val commonMain by getting {

--- a/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/BaseAndroidTestClass.kt
+++ b/src/androidInstrumentedTest/kotlin/software/momento/kotlin/sdk/BaseAndroidTestClass.kt
@@ -22,7 +22,7 @@ open class BaseAndroidTestClass {
             // Instrumented Android tests cannot access environment variables directly, so we
             // pass them in as arguments to the test runner. They are defined in build.gradle.kts.
             val arguments = InstrumentationRegistry.getArguments()
-            val apiKey = arguments.getString("TestApiKey")!!
+            val apiKey = arguments.getString("MomentoApiKey")!!
             cacheName = arguments.getString("TestCacheName")!!
             credentialProvider = CredentialProvider.fromString(apiKey)
             cacheClient = CacheClient(

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/InternalTopicClient.jvm.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/InternalTopicClient.jvm.kt
@@ -126,7 +126,6 @@ internal actual class InternalTopicClient actual constructor(
                             )
                         }
                     }
-                    println("Received message: $message")
                 }.mapNotNull { message ->
                     convertSubscriptionItem(message)
                 }.collect { (topicMessage, sequenceNumber, sequencePage) ->

--- a/src/jvmTest/kotlin/software/momento/kotlin/sdk/BaseJvmTestClass.kt
+++ b/src/jvmTest/kotlin/software/momento/kotlin/sdk/BaseJvmTestClass.kt
@@ -19,7 +19,7 @@ open class BaseJvmTestClass {
         @BeforeClass
         fun createCacheClient() {
             cacheClient = CacheClient(
-                credentialProvider = CredentialProvider.fromEnvVar("TEST_API_KEY"),
+                credentialProvider = CredentialProvider.fromEnvVar("MOMENTO_API_KEY"),
                 configuration = Configurations.Laptop.latest,
                 itemDefaultTtl = 60.seconds
             )

--- a/src/jvmTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
+++ b/src/jvmTest/kotlin/software/momento/kotlin/sdk/TopicClientTest.kt
@@ -33,7 +33,7 @@ class TopicClientTest : BaseJvmTestClass() {
         @BeforeClass
         fun setUp() {
             topicClient = TopicClient(
-                credentialProvider = CredentialProvider.fromEnvVar("TEST_API_KEY"),
+                credentialProvider = CredentialProvider.fromEnvVar("MOMENTO_API_KEY"),
                 configuration = TopicConfigurations.Laptop.latest
             )
         }


### PR DESCRIPTION
## PR Description:
- Rename TEST_API_KEY to MOMENTO_API_KEY to be consistent with other sdks
- Remove the print statement from topics which I forgot in this pr: https://github.com/momentohq/client-sdk-kotlin/pull/73
- Use correct copyright in License file