### PR TITLE
fix: disable dynamic DNS service config

### DIFF
--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/ControlGrpcStubsManager.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/ControlGrpcStubsManager.kt
@@ -43,6 +43,7 @@ internal class ControlGrpcStubsManager(credentialProvider: CredentialProvider) :
             val channelBuilder = ManagedChannelBuilder.forAddress(credentialProvider.controlEndpoint, 443)
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
+            channelBuilder.disableServiceConfigLookUp();
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
             clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey, "cache"))
             channelBuilder.intercept(clientInterceptors)

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/DataGrpcStubsManager.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/DataGrpcStubsManager.kt
@@ -46,6 +46,7 @@ internal class DataGrpcStubsManager(credentialProvider: CredentialProvider, conf
             val channelBuilder = ManagedChannelBuilder.forAddress(credentialProvider.cacheEndpoint, 443)
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
+            channelBuilder.disableServiceConfigLookUp()
             val clientInterceptors: MutableList<ClientInterceptor> = ArrayList()
             clientInterceptors.add(UserHeaderInterceptor(credentialProvider.apiKey, "cache"))
             channelBuilder.intercept(clientInterceptors)

--- a/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
+++ b/src/jvmMain/kotlin/software/momento/kotlin/sdk/internal/TopicGrpcStubsManager.kt
@@ -55,6 +55,7 @@ internal class TopicGrpcStubsManager(credentialProvider: CredentialProvider) : C
             val channelBuilder = ManagedChannelBuilder.forAddress(credentialProvider.cacheEndpoint, 443)
             channelBuilder.useTransportSecurity()
             channelBuilder.disableRetry()
+            channelBuilder.disableServiceConfigLookUp();
             channelBuilder.keepAliveTime(10, TimeUnit.SECONDS)
             channelBuilder.keepAliveTimeout(5, TimeUnit.SECONDS)
             channelBuilder.keepAliveWithoutCalls(true)


### PR DESCRIPTION
## PR Description:
- Based on the commit [here](https://github.com/googleapis/gax-java/pull/731), dynamic txt lookup for dns resolution flag is disabled by default in grpc-java. 
- This commit explicitly disables it too. 

### tcpdump when running existing example without adding the flag explicitly:
```
sudo tcpdump -i any -vvv port 53 | grep -i cache.cell-alpha-dev.preprod.a.momentohq.com           ─╯
Password:
tcpdump: data link type PKTAP
tcpdump: listening on any, link-type PKTAP (Apple DLT_PKTAP), snapshot length 524288 bytes
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.57374: [udp sum ok] 13427 q: A? control.cell-alpha-dev.preprod.a.momentohq.com. 2/0/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com., cache.cell-alpha-dev.preprod.a.momentohq.com. [1m] A 54.186.170.81 (100)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.61141: [udp sum ok] 18132 q: AAAA? control.cell-alpha-dev.preprod.a.momentohq.com. 1/1/0 control.cell-alpha-dev.preprod.a.momentohq.com. [5m] CNAME cache.cell-alpha-dev.preprod.a.momentohq.com. ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (168)
    10.0.0.249.57451 > pd1nsc3.st.vc.shawcable.net.domain: [udp sum ok] 61745+ AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. (62)
    pd1nsc3.st.vc.shawcable.net.domain > 10.0.0.249.57451: [udp sum ok] 61745 q: AAAA? cache.cell-alpha-dev.preprod.a.momentohq.com. 0/1/0 ns: cell-alpha-dev.preprod.a.momentohq.com. [15m] SOA ns-1810.awsdns-34.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400 (146)
```
You can observe that there are no TXT record lookups with existing sdk version [v0.3.0](https://github.com/momentohq/client-sdk-kotlin/releases/tag/v0.3.0)

### Relevant Research Link:
https://github.com/googleapis/gapic-generator/issues/2778
https://github.com/googleapis/gax-java/pull/731

## Issue
https://github.com/momentohq/dev-eco-issue-tracker/issues/1132